### PR TITLE
Issue#5 review

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>info.novatec</groupId>
     <artifactId>bean-test</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <name>Bean Testing</name>
     <description>Java EE Bean Testing framework</description>
     <url>http://blog.novatec-gmbh.de/unit-testing-jee-applications-cdi/</url>

--- a/src/main/java/info/novatec/beantest/api/BeanProviderHelper.java
+++ b/src/main/java/info/novatec/beantest/api/BeanProviderHelper.java
@@ -28,8 +28,8 @@ import org.apache.deltaspike.core.api.provider.BeanProvider;
  */
 public class BeanProviderHelper {
 
-    private  CdiContainer cdiContainer;
-    private static final BeanProviderHelper INSTANCE= new BeanProviderHelper();
+    private CdiContainer cdiContainer;
+    private static final BeanProviderHelper INSTANCE = new BeanProviderHelper();
 
     public static BeanProviderHelper getInstance() {
         return INSTANCE;
@@ -45,7 +45,6 @@ public class BeanProviderHelper {
         cdiContainer = CdiContainerLoader.getCdiContainer();
         cdiContainer.boot();
         cdiContainer.getContextControl().startContexts();
-
     }
 
 
@@ -84,7 +83,7 @@ public class BeanProviderHelper {
      * Shuts down the underlying container.
      */
     public void shutdown() {
-        if (cdiContainer != null) {
+        if (isCdiContainerRunning()) {
             try {
                 fireShutdownEvent();
             } finally {
@@ -94,6 +93,13 @@ public class BeanProviderHelper {
 
         }
     }
+    
+    /**
+     * Checks if the underlying BeanContainer is started and running. 
+     */
+	private boolean isCdiContainerRunning() {
+		return cdiContainer != null && cdiContainer.getBeanManager() != null;
+	}
     
     /**
      * Fires a {@link ContainerShutdown} CDI event before the CDI container shuts down in order to clean up resources (for example an

--- a/src/main/java/info/novatec/beantest/producers/EntityManagerProducer.java
+++ b/src/main/java/info/novatec/beantest/producers/EntityManagerProducer.java
@@ -58,17 +58,7 @@ public class EntityManagerProducer {
 
     @Produces
     public EntityManager getEntityManager(InjectionPoint ip) {
-        PersistenceContext ctx = ip.getAnnotated().getAnnotation(PersistenceContext.class);
-        
-        if (ctx == null) {
-        	//if @PersisteceContext is declared on method, ctx is null at this point.
-        	//ctx should be retrieved from the Method.
-        	Member member = ip.getMember();
-        	if (member instanceof Method) {
-        		Method method = (Method) member;
-        		ctx = method.getAnnotation(PersistenceContext.class);
-        	}
-        }
+        PersistenceContext ctx = retrievePersistenceContext(ip);
         
         LOGGER.debug("PersistenceContext info:");
         //This could happen if the application injects the EntityManager via @Inject instead of @PersistenceContext
@@ -83,6 +73,23 @@ public class EntityManagerProducer {
             em = emf.createEntityManager();
         }
         return em;
+    }
+    
+    private PersistenceContext retrievePersistenceContext(InjectionPoint injectionPoint) {
+        PersistenceContext ctx = injectionPoint.getAnnotated().getAnnotation(PersistenceContext.class);
+        
+        /**
+         * If @PersisteceContext is declared on method, ctx is null at this point.
+         * ctx should be retrieved from the Method object.
+         */
+        if (ctx == null) {
+        	Member member = injectionPoint.getMember();
+        	if (member instanceof Method) {
+                    Method method = (Method) member;
+                    ctx = method.getAnnotation(PersistenceContext.class);
+        	}
+        }
+        return ctx;
     }
     
     /**

--- a/src/main/java/info/novatec/beantest/transactions/TransactionalInterceptor.java
+++ b/src/main/java/info/novatec/beantest/transactions/TransactionalInterceptor.java
@@ -51,7 +51,7 @@ public class TransactionalInterceptor {
      * Exceptions that should not cause the transaction to rollback according to Java EE Documentation. 
      * (http://docs.oracle.com/javaee/6/api/javax/persistence/PersistenceException.html)
      */
-    private static final Set<Class<?>> NO_ROLLBACK_EXCEPTIONS=new HashSet<Class<?>>(Arrays.asList(
+    private static final Set<Class<?>> NO_ROLLBACK_EXCEPTIONS = new HashSet<Class<?>>(Arrays.<Class<?>>asList(
             NonUniqueResultException.class,
             NoResultException.class,
             QueryTimeoutException.class,

--- a/src/test/java/info/novatec/beantest/demo/ejb/InvalidInjectionPointConfigurationEJB.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/InvalidInjectionPointConfigurationEJB.java
@@ -1,0 +1,46 @@
+/*
+ * Bean Testing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.extension.BeanTestExtension;
+
+import javax.ejb.Stateless;
+import javax.enterprise.inject.Vetoed;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * This EJB holds an invalid dependency configuration in order to test the deployment functionality of {@link BeanTestExtension}.
+ * <p>
+ * This bean is currently vetoed due to the fact that this bean definition causes a deployment exception during the bean container bootstrapping phase.
+ * As soon there is a solution to enable alternative beans per test case this bean altogether with its corresponding test case will be reactivated.
+ * @see TestInvalidInjectionPointConfiguration
+ * @see https://www.github.com/NovaTecConsulting/BeanTest/pull/6
+ * @author Qaiser Abbasi (qaiser.abbasi@novatec-gmbh.de)
+ */
+@Stateless
+@Vetoed
+public class InvalidInjectionPointConfigurationEJB {
+
+	@PersistenceContext
+	EntityManager em;
+	
+	@PersistenceContext
+	public void setEm(EntityManager em) {
+		this.em = em;
+	}
+}

--- a/src/test/java/info/novatec/beantest/demo/ejb/TestInvalidInjectionPointConfiguration.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/TestInvalidInjectionPointConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Bean Testing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.api.BaseBeanTest;
+import info.novatec.beantest.extension.BeanTestExtension;
+
+import org.jboss.weld.exceptions.DefinitionException;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This test stress the correct deployment functionality of {@link BeanTestExtension} regarding injection point definitions of an given EJB.
+ * Due the fact that the injected bean holds an invalid dependency configuration {@link BeanTestExtension} will throw an {@link DeploymentException}.
+ * @author Qaiser Abbasi (qaiser.abbasi@novatec-gmbh.de)
+ * @see https://github.com/NovaTecConsulting/BeanTest/pull/6
+ */
+public class TestInvalidInjectionPointConfiguration extends BaseBeanTest {
+
+	/**
+	 * Ignore reason: described in {@link InvalidInjectionPointConfigurationEJB}
+	 */
+	@Test(expected = DefinitionException.class)
+	@Ignore
+	public void shouldThrowDeploymentException() {
+		getBean(InvalidInjectionPointConfigurationEJB.class);
+	}
+}


### PR DESCRIPTION
This pull request provides altogether with small code clean-ups the requested deployment validation in #5 by @carlosbarragan. BeanTestExtension is now ensuring that a processed bean holds valid dependency injection points for its member i.e. the processed bean may hold exclusively field injection points or setter injection points for a particular bean member.
