### PR TITLE
#22 Deltaspike module "testcontrol" try out

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>info.novatec</groupId>
@@ -78,6 +78,18 @@
             <groupId>org.apache.deltaspike.cdictrl</groupId>
             <artifactId>deltaspike-cdictrl-weld</artifactId>
             <version>${deltaspike.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-api</artifactId>
+            <version>${deltaspike.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-impl</artifactId>
+            <version>${deltaspike.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeEjbJpaTest.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeEjbJpaTest.java
@@ -1,0 +1,68 @@
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.demo.entities.MyEntity;
+import info.novatec.beantest.demo.exceptions.MyException;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Rewrote adjacent tests from TestEJBInjection with DeltaSpike´s "test control" module in order to compare the
+ * configurations needs, code style and importantly to check if the module provides an already solution for deploying
+ * the concepts and ideas of CDI BeanTest.
+ */
+@RunWith(CdiTestRunner.class)
+public class DeltaSpikeEjbJpaTest {
+
+    @Inject
+    private MyEJBService myService;
+    @Inject
+    private MyEJBServiceWithEntityManagerSetter myEJBServiceWithEntityManagerSetter;
+
+    @Test
+    public void shouldInjectEJBAsCDIBean() {
+        myService.callOtherServiceAndPersistAnEntity();
+        assertThat(myService.getOtherService2().getAllEntities(), hasSize(1));
+    }
+
+    @Test
+    public void shouldPersistEntityInSpiteOfException() {
+        MyEntity myEntity = new MyEntity();
+        myEntity.setName("Foo");
+        //An exception is thrown within the following method call, but because it is caught, the entity should have benn saved.
+        myService.saveEntityAndHandleException(myEntity);
+
+        assertThat(myService.getOtherService2().getAllEntities(), hasSize(1));
+
+    }
+
+    /**
+     * Verifies that the transaction is rolled back properly when an Exception is thrown and not handled.
+     */
+    @Test
+    public void shouldNotPersistEntityBecauseOfException() {
+        MyEntity myEntity = new MyEntity();
+        myEntity.setName("Foo");
+        try {
+            myService.attemptToSaveEntityAndThrowException(myEntity);
+            fail("Should have thrown an exception");
+        } catch (MyException e) {
+            assertThat(myService.getOtherService2().getAllEntities(), is(empty()));
+        }
+    }
+
+    @Test
+    public void shouldInjectEJBAsCDIBeanUsingSetter() {
+        assertNotNull(myService.getOtherService2());
+    }
+
+    @Test
+    public void shouldInjectPersistenceContextUsingSetter() {
+        assertNotNull(myEJBServiceWithEntityManagerSetter.getEm());
+    }
+}

--- a/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeMockProducerTest.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeMockProducerTest.java
@@ -1,0 +1,28 @@
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.demo.mocks.ExternalServicesMockProducer;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(CdiTestRunner.class)
+public class DeltaSpikeMockProducerTest {
+
+    @Inject
+    private MyEjbServiceThatCallsAnExternalService service;
+
+    @Test
+    public void shouldCallExternalServiceMock() {
+        MyExternalService externalService = ExternalServicesMockProducer.getExternalService();
+        //Since the ExternalServicesMockProducer returns a Mockito mock, we can initialize it
+        Mockito.when(externalService.doSomething()).thenReturn("Hello World");
+
+        assertThat(service.callExternalService(), is("Hello World"));
+    }
+}

--- a/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikePersistenceExceptionPropagationTest.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikePersistenceExceptionPropagationTest.java
@@ -1,0 +1,28 @@
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.demo.entities.MyEntityWithConstraints;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.persistence.PersistenceException;
+
+import static org.junit.Assert.fail;
+
+@RunWith(CdiTestRunner.class)
+public class DeltaSpikePersistenceExceptionPropagationTest {
+
+    @Inject
+    private MyEJBService myEJBService;
+
+    @Test(expected = PersistenceException.class)
+    public void shouldCauseExceptionBecuaseUniquenessViolation() {
+        MyEntityWithConstraints entity = new MyEntityWithConstraints("123");
+        myEJBService.save(entity);
+        entity = new MyEntityWithConstraints("123");
+        myEJBService.save(entity);
+        fail("Should have failed because uniqueness violation");
+    }
+
+}

--- a/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeRollbackExceptionTest.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeRollbackExceptionTest.java
@@ -1,0 +1,42 @@
+package info.novatec.beantest.demo.ejb;
+
+import info.novatec.beantest.demo.entities.MyEntity;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.persistence.NoResultException;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(CdiTestRunner.class)
+public class DeltaSpikeRollbackExceptionTest {
+
+    @Inject
+    private MyEJBService myEJBService;
+
+    @Test
+    public void shouldExceptionNoCauseRollback() {
+        MyOtherEJBService myOtherEJBService = myEJBService.getOtherService2();
+
+        assertThat(myOtherEJBService.getAllEntities(), hasSize(0));
+
+        MyEntity entity = new MyEntity();
+        entity.setName("some name");
+        try {
+            myEJBService.saveEntityAndCausePersistenceExceptionWithoutRollback(entity);
+            fail("Should have thrown PersistenceException");
+        } catch (NoResultException exception) {
+            assertThat(exception, not(nullValue()));
+        }
+
+
+        //Entity should have been saved
+        assertThat(myOtherEJBService.getAllEntities(), hasSize(1));
+
+    }
+
+}

--- a/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeSingletonInjectionTest.java
+++ b/src/test/java/info/novatec/beantest/demo/ejb/DeltaSpikeSingletonInjectionTest.java
@@ -1,0 +1,24 @@
+package info.novatec.beantest.demo.ejb;
+
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(CdiTestRunner.class)
+public class DeltaSpikeSingletonInjectionTest {
+
+    @Inject
+    private MyEjbSingleton singleton;
+
+    @Test
+    public void shouldBeInstantiatedOnce() {
+        assertThat(singleton.wasEjbCalled(), is(false));
+        singleton.callAnEjb();
+        assertThat(singleton.wasEjbCalled(), is(true));
+    }
+}


### PR DESCRIPTION
Rewrote adjacent tests with DeltaSpike´s "test control" module in order to compare the configurations needs, code style and importantly to check if the module provides an already solution for deploying the concepts and ideas of CDI BeanTest.